### PR TITLE
Add Prisma schema and migration setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -113,20 +113,3 @@ Stack Tecnológico Sugerido (Backend y Base de Datos)
 
 Dado que el backend será en Node.js (requisito confirmado), se propondrá una pila tecnológica centrada en el ecosistema JavaScript, complementada con una base de datos robusta y servicios externos según necesidad:
 
-- Backend en Node.js con Express para exponer una API RESTful.
-- PostgreSQL como base de datos utilizando Prisma como ORM.
-- Integraciones con servicios externos como SendGrid y Twilio para correos y mensajes.
-
-## Prisma Models
-
-The project uses [Prisma](https://www.prisma.io/) as ORM. The schema is defined in `prisma/schema.prisma` and covers:
-
-- `Usuario` – registered users
-- `Grupo` – quiniela groups linked to a `Torneo`
-- `Participacion` – membership relation between users and groups
-- `Torneo` – tournament definitions
-- `Equipo` – teams participating in a tournament
-- `Partido` – matches between teams
-- `Pronostico` – predictions made by users for each match
-
-Run `npm install` and adjust the `DATABASE_URL` in `.env` to connect to PostgreSQL. Migrations are located in `prisma/migrations`.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ Stack Tecnológico Sugerido (Backend y Base de Datos)
 
 Dado que el backend será en Node.js (requisito confirmado), se propondrá una pila tecnológica centrada en el ecosistema JavaScript, complementada con una base de datos robusta y servicios externos según necesidad:
 
-
+- Backend en Node.js con Express para exponer una API RESTful.
+- PostgreSQL como base de datos utilizando Prisma como ORM.
+- Integraciones con servicios externos como SendGrid y Twilio para correos y mensajes.
 
 ## Prisma Models
 

--- a/README.md
+++ b/README.md
@@ -113,3 +113,18 @@ Stack Tecnológico Sugerido (Backend y Base de Datos)
 
 Dado que el backend será en Node.js (requisito confirmado), se propondrá una pila tecnológica centrada en el ecosistema JavaScript, complementada con una base de datos robusta y servicios externos según necesidad:
 
+
+
+## Prisma Models
+
+The project uses [Prisma](https://www.prisma.io/) as ORM. The schema is defined in `prisma/schema.prisma` and covers:
+
+- `Usuario` – registered users
+- `Grupo` – quiniela groups linked to a `Torneo`
+- `Participacion` – membership relation between users and groups
+- `Torneo` – tournament definitions
+- `Equipo` – teams participating in a tournament
+- `Partido` – matches between teams
+- `Pronostico` – predictions made by users for each match
+
+Run `npm install` and adjust the `DATABASE_URL` in `.env` to connect to PostgreSQL. Migrations are located in `prisma/migrations`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,136 @@
+{
+  "name": "quinielapp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "quinielapp",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@prisma/client": "^6.9.0",
+        "prisma": "^6.9.0"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.9.0.tgz",
+      "integrity": "sha512-Gg7j1hwy3SgF1KHrh0PZsYvAaykeR0PaxusnLXydehS96voYCGt1U5zVR31NIouYc63hWzidcrir1a7AIyCsNQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
+      "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
+      "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
+      "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/fetch-engine": "6.9.0",
+        "@prisma/get-platform": "6.9.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
+      "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
+      "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/get-platform": "6.9.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
+      "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
+      "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.9.0",
+        "@prisma/engines": "6.9.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "quinielapp",
+  "version": "1.0.0",
+  "description": "Plan de Desarrollo para Aplicación Web de Quinielas de Fútbol",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@prisma/client": "^6.9.0",
+    "prisma": "^6.9.0"
+  }
+}

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -1,0 +1,19 @@
+# Prisma setup
+
+This folder contains the Prisma schema and migration files.
+
+1. Update the `.env` file at the project root with your PostgreSQL connection string:
+   ```
+   DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/quinieladb?schema=public"
+   ```
+2. Install dependencies:
+   ```
+   npm install
+   ```
+3. Apply migrations and generate the client (requires Prisma CLI):
+   ```
+   npx prisma migrate deploy
+   npx prisma generate
+   ```
+
+The initial migration is in `migrations/0001_init/migration.sql`.

--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,64 @@
+-- Initial schema for quinielApp using PostgreSQL
+CREATE TABLE "Usuario" (
+  "id" SERIAL PRIMARY KEY,
+  "email" TEXT NOT NULL UNIQUE,
+  "telefono" TEXT,
+  "password" TEXT NOT NULL,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE "Torneo" (
+  "id" SERIAL PRIMARY KEY,
+  "nombre" TEXT NOT NULL,
+  "year" INTEGER NOT NULL,
+  "startDate" TIMESTAMPTZ NOT NULL,
+  "endDate" TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE "Grupo" (
+  "id" SERIAL PRIMARY KEY,
+  "nombre" TEXT NOT NULL,
+  "descripcion" TEXT,
+  "code" TEXT NOT NULL UNIQUE,
+  "torneoId" INTEGER NOT NULL REFERENCES "Torneo"("id"),
+  "adminId" INTEGER NOT NULL REFERENCES "Usuario"("id")
+);
+
+CREATE TABLE "Participacion" (
+  "id" SERIAL PRIMARY KEY,
+  "userId" INTEGER NOT NULL REFERENCES "Usuario"("id"),
+  "grupoId" INTEGER NOT NULL REFERENCES "Grupo"("id"),
+  "puntos" INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE "Equipo" (
+  "id" SERIAL PRIMARY KEY,
+  "nombre" TEXT NOT NULL,
+  "torneoId" INTEGER NOT NULL REFERENCES "Torneo"("id")
+);
+
+CREATE TABLE "Partido" (
+  "id" SERIAL PRIMARY KEY,
+  "torneoId" INTEGER NOT NULL REFERENCES "Torneo"("id"),
+  "localId" INTEGER NOT NULL REFERENCES "Equipo"("id"),
+  "visitanteId" INTEGER NOT NULL REFERENCES "Equipo"("id"),
+  "fecha" TIMESTAMPTZ NOT NULL,
+  "golesLocal" INTEGER,
+  "golesVisitante" INTEGER
+);
+
+CREATE TABLE "Pronostico" (
+  "id" SERIAL PRIMARY KEY,
+  "userId" INTEGER NOT NULL REFERENCES "Usuario"("id"),
+  "partidoId" INTEGER NOT NULL REFERENCES "Partido"("id"),
+  "grupoId" INTEGER NOT NULL REFERENCES "Grupo"("id"),
+  "golesLocal" INTEGER NOT NULL,
+  "golesVisitante" INTEGER NOT NULL,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX "participacion_user_idx" ON "Participacion"("userId");
+CREATE INDEX "participacion_grupo_idx" ON "Participacion"("grupoId");
+CREATE INDEX "pronostico_user_idx" ON "Pronostico"("userId");
+CREATE INDEX "pronostico_partido_idx" ON "Pronostico"("partidoId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,92 @@
+// Prisma schema for quinielApp
+
+// Datasource uses PostgreSQL connection from .env
+ datasource db {
+   provider = "postgresql"
+   url      = env("DATABASE_URL")
+ }
+
+ generator client {
+   provider = "prisma-client-js"
+ }
+
+ model Usuario {
+   id          Int             @id @default(autoincrement())
+   email       String          @unique
+   telefono    String?
+   password    String
+   createdAt   DateTime        @default(now())
+   updatedAt   DateTime        @updatedAt
+   grupos      Grupo[]         @relation("GrupoAdmin")
+   participaciones Participacion[]
+   pronosticos Pronostico[]
+ }
+
+ model Grupo {
+   id          Int             @id @default(autoincrement())
+   nombre      String
+   descripcion String?
+   code        String          @unique
+   torneo      Torneo          @relation(fields: [torneoId], references: [id])
+   torneoId    Int
+   admin       Usuario         @relation("GrupoAdmin", fields: [adminId], references: [id])
+   adminId     Int
+   participaciones Participacion[]
+   pronosticos Pronostico[]
+ }
+
+ model Participacion {
+   id       Int     @id @default(autoincrement())
+   user     Usuario @relation(fields: [userId], references: [id])
+   userId   Int
+   grupo    Grupo   @relation(fields: [grupoId], references: [id])
+   grupoId  Int
+   puntos   Int     @default(0)
+ }
+
+ model Torneo {
+   id        Int       @id @default(autoincrement())
+   nombre    String
+   year      Int
+   startDate DateTime
+   endDate   DateTime
+   equipos   Equipo[]
+   grupos    Grupo[]
+   partidos  Partido[]
+ }
+
+ model Equipo {
+   id        Int      @id @default(autoincrement())
+   nombre    String
+   torneo    Torneo   @relation(fields: [torneoId], references: [id])
+   torneoId  Int
+   partidosLocal     Partido[] @relation("LocalEquipo")
+   partidosVisitante Partido[] @relation("VisitanteEquipo")
+ }
+
+ model Partido {
+   id            Int       @id @default(autoincrement())
+   torneo        Torneo    @relation(fields: [torneoId], references: [id])
+   torneoId      Int
+   local         Equipo    @relation("LocalEquipo", fields: [localId], references: [id])
+   localId       Int
+   visitante     Equipo    @relation("VisitanteEquipo", fields: [visitanteId], references: [id])
+   visitanteId   Int
+   fecha         DateTime
+   golesLocal    Int?
+   golesVisitante Int?
+   pronosticos   Pronostico[]
+ }
+
+ model Pronostico {
+   id            Int       @id @default(autoincrement())
+   user          Usuario   @relation(fields: [userId], references: [id])
+   userId        Int
+   partido       Partido   @relation(fields: [partidoId], references: [id])
+   partidoId     Int
+   grupo         Grupo     @relation(fields: [grupoId], references: [id])
+   grupoId       Int
+   golesLocal    Int
+   golesVisitante Int
+   createdAt     DateTime  @default(now())
+ }


### PR DESCRIPTION
## Summary
- initialize Node project with Prisma dependencies
- add Prisma schema for main entities
- include initial SQL migration and setup notes
- document Prisma usage in README
- provide example PostgreSQL configuration

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f1eae3f90832f85fb5d56a62d4140