### PR TITLE
Add Express server with user auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# PostgreSQL connection string
+DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/quinieladb?schema=public"
+
+# Secret key for JWT tokens
+JWT_SECRET="your_jwt_secret"

--- a/README.md
+++ b/README.md
@@ -117,3 +117,18 @@ Dado que el backend será en Node.js (requisito confirmado), se propondrá una p
 - **Lenguaje**: se recomienda TypeScript para aprovechar tipado estático y mejorar el mantenimiento del código.
 - **Base de datos**: PostgreSQL como motor relacional robusto y ampliamente soportado.
 - **ORM y migraciones**: puede emplearse Prisma o TypeORM para modelar entidades y ejecutar consultas de manera sencilla; ambos ofrecen herramientas de migraciones (Prisma Migrate o TypeORM migrations) para versionar el esquema.
+
+## Ejecutar backend
+
+1. Copia `.env.example` a `.env` y actualiza `DATABASE_URL` y `JWT_SECRET`.
+2. Instala dependencias con `npm install`.
+3. Ejecuta las migraciones de Prisma:
+   ```
+   npx prisma migrate deploy
+   npx prisma generate
+   ```
+4. Inicia el servidor:
+   ```
+   npm start
+   ```
+El API estará disponible en `http://localhost:3000`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Plan de Desarrollo para Aplicación Web de Quinielas de Fútbol",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js"
   },
   "keywords": [],
   "author": "",
@@ -12,6 +14,14 @@
   "type": "commonjs",
   "devDependencies": {
     "@prisma/client": "^6.9.0",
-    "prisma": "^6.9.0"
+    "prisma": "^6.9.0",
+    "nodemon": "^3.0.2"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.0",
+    "dotenv": "^16.3.1",
+    "morgan": "^1.10.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const morgan = require('morgan');
+require('dotenv').config();
+
+const authRoutes = require('./routes/auth');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(morgan('dev'));
+app.use(express.json());
+
+app.use('/api', authRoutes);
+
+app.get('/', (req, res) => {
+  res.send('quinielApp API');
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/prismaClient.js
+++ b/src/prismaClient.js
@@ -1,0 +1,5 @@
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+module.exports = prisma;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const prisma = require('../prismaClient');
+
+const router = express.Router();
+
+// Register new user
+router.post('/register', async (req, res) => {
+  const { email, telefono, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email y password son requeridos' });
+  }
+  try {
+    const existing = await prisma.usuario.findUnique({ where: { email } });
+    if (existing) {
+      return res.status(409).json({ message: 'El usuario ya existe' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await prisma.usuario.create({
+      data: {
+        email,
+        telefono,
+        password: hashed,
+      },
+    });
+    res.status(201).json({ id: user.id, email: user.email });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al registrar usuario' });
+  }
+});
+
+// Authenticate user
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email y password son requeridos' });
+  }
+  try {
+    const user = await prisma.usuario.findUnique({ where: { email } });
+    if (!user) {
+      return res.status(401).json({ message: 'Credenciales inválidas' });
+    }
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) {
+      return res.status(401).json({ message: 'Credenciales inválidas' });
+    }
+    const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET || 'secret', {
+      expiresIn: '1d',
+    });
+    res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al iniciar sesión' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- set up Express server under `src`
- add registration and login routes using Prisma
- document backend setup steps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f316f5df8832f949009056cce06d8