### PR TITLE
Implement user dashboard with group management and tournament scraper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcryptjs": "^2.4.3",
+        "cheerio": "^1.0.0-rc.12",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.0",
@@ -1878,6 +1879,12 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2061,6 +2068,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
+      "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.10.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -2322,6 +2371,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2406,6 +2483,61 @@
         "wrappy": "1"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
@@ -2488,6 +2620,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -3067,6 +3236,37 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -4583,6 +4783,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -4721,6 +4933,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -5750,6 +6011,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
+      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -5873,6 +6143,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "cheerio": "^1.0.0-rc.12"
   }
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard</title>
+</head>
+<body>
+  <h1>Dashboard</h1>
+  <nav>
+    <button id="loadGroups">Mis Grupos</button>
+    <button id="scrape">Cargar Torneo</button>
+  </nav>
+
+  <section>
+    <h2>Crear Grupo</h2>
+    <form id="createGroupForm">
+      <input type="text" id="groupName" placeholder="Nombre" required>
+      <input type="text" id="groupDesc" placeholder="Descripción">
+      <input type="number" id="torneoId" placeholder="Torneo ID" required>
+      <button type="submit">Crear</button>
+    </form>
+  </section>
+
+  <section>
+    <h2>Unirse a Grupo</h2>
+    <form id="joinGroupForm">
+      <input type="text" id="joinCode" placeholder="Código" required>
+      <button type="submit">Unirse</button>
+    </form>
+  </section>
+
+  <h2>Grupos</h2>
+  <ul id="groups"></ul>
+
+  <script>
+  const token = localStorage.getItem('token');
+
+  document.getElementById('scrape').onclick = async () => {
+    const res = await fetch('/api/scrape/torneo', {
+      method: 'POST',
+      headers: { 'Authorization': 'Bearer ' + token }
+    });
+    alert(await res.text());
+  };
+
+  document.getElementById('createGroupForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const res = await fetch('/api/groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+      body: JSON.stringify({
+        nombre: document.getElementById('groupName').value,
+        descripcion: document.getElementById('groupDesc').value,
+        torneoId: parseInt(document.getElementById('torneoId').value)
+      })
+    });
+    alert(await res.text());
+  });
+
+  document.getElementById('joinGroupForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const res = await fetch('/api/groups/join', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+      body: JSON.stringify({ code: document.getElementById('joinCode').value })
+    });
+    alert(await res.text());
+  });
+
+  document.getElementById('loadGroups').onclick = async () => {
+    const res = await fetch('/api/groups', {
+      headers: { 'Authorization': 'Bearer ' + token }
+    });
+    const groups = await res.json();
+    const list = document.getElementById('groups');
+    list.innerHTML = '';
+    groups.forEach(g => {
+      const li = document.createElement('li');
+      li.textContent = g.nombre + ' (' + g.code + ')';
+      list.appendChild(li);
+    });
+  };
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -44,7 +44,13 @@ document.getElementById('loginForm').addEventListener('submit', async (e) => {
       password: document.getElementById('logPass').value
     })
   });
-  document.getElementById('output').textContent = await res.text();
+  if(res.ok){
+    const data = await res.json();
+    localStorage.setItem('token', data.token);
+    window.location.href = '/dashboard.html';
+  } else {
+    document.getElementById('output').textContent = await res.text();
+  }
 });
 </script>
 </body>

--- a/public/torneo_sample.html
+++ b/public/torneo_sample.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head><title>Torneo Sample</title></head>
+<body>
+<h1>Mundial de Clubes 2025</h1>
+<table id="equipos">
+<tr><th>Equipo</th></tr>
+<tr><td>Real Madrid</td></tr>
+<tr><td>Manchester City</td></tr>
+</table>
+<table id="partidos">
+<tr><th>Local</th><th>Visitante</th><th>Fecha</th></tr>
+<tr><td>Real Madrid</td><td>Manchester City</td><td>2025-06-20</td></tr>
+</table>
+</body>
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ const morgan = require('morgan');
 require('dotenv').config();
 
 const authRoutes = require('./routes/auth');
+const groupsRoutes = require('./routes/groups');
+const scrapeRoutes = require('./routes/scrape');
 const path = require('path');
 
 const app = express();
@@ -13,6 +15,8 @@ app.use(express.json());
 app.use(express.static(path.join(__dirname, '..', 'public')));
 
 app.use('/api', authRoutes);
+app.use('/api/groups', groupsRoutes);
+app.use('/api/scrape', scrapeRoutes);
 
 app.get('/', (req, res) => {
   res.send('quinielApp API');

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,14 @@
+const jwt = require('jsonwebtoken');
+
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'Token requerido' });
+  jwt.verify(token, process.env.JWT_SECRET || 'secret', (err, payload) => {
+    if (err) return res.status(403).json({ message: 'Token inválido' });
+    req.userId = payload.userId;
+    next();
+  });
+}
+
+module.exports = authenticateToken;

--- a/src/routes/groups.js
+++ b/src/routes/groups.js
@@ -1,0 +1,74 @@
+const express = require('express');
+const prisma = require('../prismaClient');
+const authenticateToken = require('../middleware/auth');
+
+const router = express.Router();
+
+function generateCode() {
+  return Math.random().toString(36).substring(2, 8);
+}
+
+// Create a new group
+router.post('/', authenticateToken, async (req, res) => {
+  const { nombre, descripcion, torneoId } = req.body;
+  if (!nombre || !torneoId) {
+    return res.status(400).json({ message: 'Nombre y torneoId requeridos' });
+  }
+  try {
+    const grupo = await prisma.grupo.create({
+      data: {
+        nombre,
+        descripcion,
+        code: generateCode(),
+        torneoId,
+        adminId: req.userId,
+      },
+    });
+    // add creator as participant
+    await prisma.participacion.create({
+      data: { userId: req.userId, grupoId: grupo.id },
+    });
+    res.status(201).json(grupo);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al crear grupo' });
+  }
+});
+
+// Join a group by code
+router.post('/join', authenticateToken, async (req, res) => {
+  const { code } = req.body;
+  if (!code) return res.status(400).json({ message: 'Code requerido' });
+  try {
+    const grupo = await prisma.grupo.findUnique({ where: { code } });
+    if (!grupo) return res.status(404).json({ message: 'Grupo no encontrado' });
+    const exists = await prisma.participacion.findFirst({
+      where: { userId: req.userId, grupoId: grupo.id },
+    });
+    if (exists) return res.status(409).json({ message: 'Ya en el grupo' });
+    await prisma.participacion.create({
+      data: { userId: req.userId, grupoId: grupo.id },
+    });
+    res.json({ message: 'Unido al grupo' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al unirse al grupo' });
+  }
+});
+
+// List groups for user
+router.get('/', authenticateToken, async (req, res) => {
+  try {
+    const participaciones = await prisma.participacion.findMany({
+      where: { userId: req.userId },
+      include: { grupo: true },
+    });
+    const grupos = participaciones.map((p) => p.grupo);
+    res.json(grupos);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al obtener grupos' });
+  }
+});
+
+module.exports = router;

--- a/src/routes/scrape.js
+++ b/src/routes/scrape.js
@@ -1,0 +1,63 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const cheerio = require('cheerio');
+const prisma = require('../prismaClient');
+const authenticateToken = require('../middleware/auth');
+
+const router = express.Router();
+
+router.post('/torneo', authenticateToken, async (req, res) => {
+  try {
+    const html = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'torneo_sample.html'), 'utf8');
+    const $ = cheerio.load(html);
+    const title = $('h1').text(); // e.g., Mundial de Clubes 2025
+    const parts = title.split(' ');
+    const year = parseInt(parts.pop(), 10);
+    const nombre = parts.join(' ');
+
+    const torneo = await prisma.torneo.create({
+      data: {
+        nombre: nombre.trim(),
+        year,
+        startDate: new Date('2025-06-20'),
+        endDate: new Date('2025-07-05'),
+      },
+    });
+
+    const equipos = [];
+    $('#equipos tr td').each((_, el) => {
+      equipos.push($(el).text());
+    });
+
+    for (const eq of equipos) {
+      await prisma.equipo.create({ data: { nombre: eq, torneoId: torneo.id } });
+    }
+
+    $('#partidos tr').slice(1).each(async (_, el) => {
+      const tds = $(el).find('td');
+      const localName = $(tds[0]).text();
+      const visitanteName = $(tds[1]).text();
+      const fecha = new Date($(tds[2]).text());
+      const local = await prisma.equipo.findFirst({ where: { nombre: localName, torneoId: torneo.id } });
+      const visitante = await prisma.equipo.findFirst({ where: { nombre: visitanteName, torneoId: torneo.id } });
+      if (local && visitante) {
+        await prisma.partido.create({
+          data: {
+            torneoId: torneo.id,
+            localId: local.id,
+            visitanteId: visitante.id,
+            fecha,
+          },
+        });
+      }
+    });
+
+    res.json({ message: 'Torneo cargado', torneoId: torneo.id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al procesar torneo' });
+  }
+});
+
+module.exports = router;

--- a/tests/groups.test.js
+++ b/tests/groups.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+
+// Mock prisma client
+jest.mock('../src/prismaClient', () => ({
+  grupo: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+  },
+  participacion: {
+    create: jest.fn(),
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+  },
+}));
+
+const prisma = require('../src/prismaClient');
+const groupsRoutes = require('../src/routes/groups');
+const authMiddleware = require('../src/middleware/auth');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/groups', groupsRoutes);
+  return app;
+}
+
+function generateToken(id = 1) {
+  return jwt.sign({ userId: id }, 'secret');
+}
+
+describe('Groups routes', () => {
+  let app;
+  beforeEach(() => {
+    app = createApp();
+    jest.clearAllMocks();
+  });
+
+  test('creates a group', async () => {
+    prisma.grupo.create.mockResolvedValue({ id: 1, code: 'abc123' });
+    prisma.participacion.create.mockResolvedValue();
+    const res = await request(app)
+      .post('/api/groups')
+      .set('Authorization', 'Bearer ' + generateToken())
+      .send({ nombre: 'Test', torneoId: 2 });
+    expect(res.statusCode).toBe(201);
+    expect(prisma.grupo.create).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- install `cheerio`
- add auth middleware
- build group routes (create/join/list)
- add scraping route to load tournament data from a sample html file
- extend server to include new routes
- add dashboard page and enhance login to redirect with token
- add sample tournament html
- provide basic test for groups route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f43b42594832fa9843c9cf24216c7