### PR TITLE
Add group invitation links and registration via code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Creación y gestión de grupos de quiniela
 Creación de grupos: Un usuario autenticado podrá crear un grupo de quiniela, actuando como administrador de ese grupo. Al crear un grupo, deberá asociarlo a un torneo específico (por ejemplo, "Mundial de Clubes FIFA 2025") que esté cargado en la base de datos. Cada grupo corresponde a un único torneo; esto simplifica la lógica ya que las predicciones de un grupo se refieren todas a los partidos de ese torneo.
 
 Invitaciones mediante código único: Tras crear el grupo, la aplicación generará un código de invitación único (p. ej., un alfanumérico corto) que el administrador podrá compartir con sus amigos. Los usuarios podrán unirse al grupo ingresando este código en la app. Alternativamente, se puede implementar un enlace de invitación que incluya el código para mayor facilidad de uso (ej. https://miquiniela.app/invitacion/ABC123).
+La aplicación devuelve este enlace dentro de la lista de grupos del usuario en el campo `inviteLink`, para que pueda compartirse fácilmente.
 
 Unirse a grupos existentes: Cualquier usuario registrado puede unirse a un grupo introduciendo el código de invitación, siempre que cumpla ciertas condiciones: (a) el grupo no haya alcanzado el límite de participantes, si es que definimos uno; (b) el torneo asociado al grupo esté activo y no demasiado avanzado (ver restricciones más abajo). Al unirse, el usuario comenzará con 0 puntos en ese grupo y podrá hacer sus pronósticos para los partidos pendientes.
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -77,7 +77,10 @@
     list.innerHTML = '';
     groups.forEach(g => {
       const li = document.createElement('li');
-      li.textContent = g.nombre + ' (' + g.code + ')';
+      const a = document.createElement('a');
+      a.href = g.inviteLink;
+      a.textContent = g.nombre + ' (' + g.code + ')';
+      li.appendChild(a);
       list.appendChild(li);
     });
   };

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
   <form id="registerForm">
     <input type="email" id="regEmail" placeholder="Email" required>
     <input type="password" id="regPass" placeholder="Password" required>
+    <input type="hidden" id="groupCode">
     <button type="submit">Register</button>
   </form>
   <h2>Login</h2>
@@ -21,6 +22,10 @@
   </form>
   <pre id="output"></pre>
 <script>
+const params = new URLSearchParams(window.location.search);
+const code = params.get('code');
+if (code) document.getElementById('groupCode').value = code;
+
 document.getElementById('registerForm').addEventListener('submit', async (e) => {
   e.preventDefault();
   const res = await fetch('/api/register', {
@@ -28,7 +33,8 @@ document.getElementById('registerForm').addEventListener('submit', async (e) => 
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       email: document.getElementById('regEmail').value,
-      password: document.getElementById('regPass').value
+      password: document.getElementById('regPass').value,
+      groupCode: document.getElementById('groupCode').value || undefined
     })
   });
   document.getElementById('output').textContent = await res.text();

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -7,7 +7,7 @@ const router = express.Router();
 
 // Register new user
 router.post('/register', async (req, res) => {
-  const { email, telefono, password } = req.body;
+  const { email, telefono, password, groupCode } = req.body;
   if (!email || !password) {
     return res.status(400).json({ message: 'Email y password son requeridos' });
   }
@@ -24,6 +24,15 @@ router.post('/register', async (req, res) => {
         password: hashed,
       },
     });
+    if (groupCode) {
+      const grupo = await prisma.grupo.findUnique({ where: { code: groupCode } });
+      if (!grupo) {
+        return res.status(400).json({ message: 'Código de grupo inválido' });
+      }
+      await prisma.participacion.create({
+        data: { userId: user.id, grupoId: grupo.id },
+      });
+    }
     res.status(201).json({ id: user.id, email: user.email });
   } catch (err) {
     console.error(err);

--- a/src/routes/groups.js
+++ b/src/routes/groups.js
@@ -63,7 +63,11 @@ router.get('/', authenticateToken, async (req, res) => {
       where: { userId: req.userId },
       include: { grupo: true },
     });
-    const grupos = participaciones.map((p) => p.grupo);
+    const base = process.env.BASE_URL || `http://localhost:${process.env.PORT || 3000}`;
+    const grupos = participaciones.map((p) => ({
+      ...p.grupo,
+      inviteLink: `${base}/index.html?code=${p.grupo.code}`,
+    }));
     res.json(grupos);
   } catch (err) {
     console.error(err);

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -8,6 +8,12 @@ jest.mock('../src/prismaClient', () => ({
     findUnique: jest.fn(),
     create: jest.fn(),
   },
+  grupo: {
+    findUnique: jest.fn(),
+  },
+  participacion: {
+    create: jest.fn(),
+  },
 }));
 
 const prisma = require('../src/prismaClient');
@@ -38,6 +44,22 @@ describe('Auth routes', () => {
 
     expect(res.statusCode).toBe(201);
     expect(prisma.usuario.create).toHaveBeenCalled();
+  });
+
+  test('registers and joins group when code provided', async () => {
+    prisma.usuario.findUnique.mockResolvedValue(null);
+    prisma.usuario.create.mockResolvedValue({ id: 2, email: 'user2@test.com' });
+    prisma.grupo.findUnique.mockResolvedValue({ id: 5, code: 'abc123' });
+    prisma.participacion.create.mockResolvedValue();
+
+    const res = await request(app)
+      .post('/api/register')
+      .send({ email: 'user2@test.com', password: 'secret', groupCode: 'abc123' });
+
+    expect(res.statusCode).toBe(201);
+    expect(prisma.participacion.create).toHaveBeenCalledWith({
+      data: { userId: 2, grupoId: 5 },
+    });
   });
 
   test('logs in an existing user', async () => {

--- a/tests/groups.test.js
+++ b/tests/groups.test.js
@@ -47,4 +47,15 @@ describe('Groups routes', () => {
     expect(res.statusCode).toBe(201);
     expect(prisma.grupo.create).toHaveBeenCalled();
   });
+
+  test('lists groups with invite link', async () => {
+    prisma.participacion.findMany.mockResolvedValue([
+      { grupo: { id: 1, nombre: 'Test', code: 'abc123' } },
+    ]);
+    const res = await request(app)
+      .get('/api/groups')
+      .set('Authorization', 'Bearer ' + generateToken());
+    expect(res.statusCode).toBe(200);
+    expect(res.body[0].inviteLink).toContain('abc123');
+  });
 });


### PR DESCRIPTION
## Summary
- add registration link to group listing
- allow registering with a group invitation code
- show join link in dashboard and accept link on registration page
- update README docs
- expand tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f4ba2f9f0832fac98a01a011bf5f1